### PR TITLE
CR

### DIFF
--- a/src/main/java/pl/jakubkozlowski/learning/firststeps/controller/ChampionController.java
+++ b/src/main/java/pl/jakubkozlowski/learning/firststeps/controller/ChampionController.java
@@ -30,12 +30,12 @@ public class ChampionController {
 
     @GetMapping(value = BY_ID)
     public ResponseEntity<Champion> findOne(@PathVariable("id") Long id) {
-        return ResponseEntity.ok(championMapper.findOne(id));
+        return ResponseEntity.ok(championMapper.findById(id));
     }
 
     @PostMapping
-    public ResponseEntity<Champion> create(@RequestBody Champion champion) {
-         championMapper.create(champion);
+    public ResponseEntity<Champion> persist(@RequestBody Champion champion) {
+         championMapper.persist(champion);
          return ResponseEntity.status(HttpStatus.CREATED).body(champion);
     }
 

--- a/src/main/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapper.java
+++ b/src/main/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapper.java
@@ -1,6 +1,7 @@
 package pl.jakubkozlowski.learning.firststeps.mapper;
 
 import org.apache.ibatis.annotations.*;
+import org.springframework.http.ResponseEntity;
 import pl.jakubkozlowski.learning.firststeps.model.Champion;
 
 import java.util.List;
@@ -9,11 +10,15 @@ import java.util.List;
 public interface ChampionMapper{
 
 
-    @Insert("INSERT INTO champion VALUES ( #{champion.id}, #{champion.name} )")
-    void create(@Param("champion") Champion champion);
+    @Insert("INSERT INTO champion (name) VALUES (#{champion.name})")
+    @Options(useGeneratedKeys = true, keyProperty = "champion.id")
+    void persist(@Param("champion") Champion champion);
 
     @Select("SELECT * FROM champion WHERE id= #{id}")
-    Champion findOne(@Param("id") Long id);
+    Champion findById(@Param("id") Long id);
+
+    @Select("SELECT * FROM champion WHERE name= #{name}")
+    Champion findByName(@Param("name") String name);
 
     @Select("SELECT * FROM champion")
     List<Champion> findAll();
@@ -23,7 +28,6 @@ public interface ChampionMapper{
 
     @Delete("DELETE FROM champion WHERE id=#{id}")
     void deleteById(@Param("id") Long id);
-
 
 }
 

--- a/src/main/java/pl/jakubkozlowski/learning/firststeps/model/Champion.java
+++ b/src/main/java/pl/jakubkozlowski/learning/firststeps/model/Champion.java
@@ -15,6 +15,11 @@ public class Champion{
         this.id = id;
         this.name = name;
     }
+
+    public Champion(String name) {
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/test/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapperTest.java
+++ b/src/test/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapperTest.java
@@ -3,13 +3,11 @@ package pl.jakubkozlowski.learning.firststeps.mapper;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import pl.jakubkozlowski.learning.firststeps.model.Champion;
 
@@ -19,88 +17,118 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @MybatisTest
+//For autoincrement reset between tests
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class ChampionMapperTest {
+
+    private static final String AATROX = "Aatrox";
+    private static final String AHRI = "Ahri";
 
     @Autowired
     private ChampionMapper championMapper;
-    private Champion expected;
-    private Champion expected2;
+    private Champion expectedAatrox;
+    private Champion expectedAhri;
 
 
     @Before
     public void setUp() throws Exception {
-        expected = new Champion(1L, "Aatrox");
-//        System.out.println(championMapper);
+        expectedAatrox = new Champion(1L, AATROX);
+        expectedAhri = new Champion(2L, AHRI);
     }
 
     @Test
     public void whenFindOne_thenReturnChampion() {
         //given
-        championMapper.create(expected);
+        championMapper.persist(expectedAatrox);
         //when
-        Champion actual = championMapper.findOne(1L);
+        Champion actual = championMapper.findById(1L);
         //then
         assertThat(actual)
-                .isEqualTo(expected);
+                .isEqualTo(expectedAatrox);
     }
 
     @Test
-    public void whenFindAll_thenReturnChampions(){
+    public void whenFindAll_thenReturnChampionList(){
         //given
-        expected2 = new Champion(2L, "Ahri");
-        championMapper.create(expected);
-        championMapper.create(expected2);
+        championMapper.persist(expectedAatrox);
+        championMapper.persist(expectedAhri);
         //when
         List<Champion> actual = championMapper.findAll();
         //then
         assertThat(actual.get(0))
-                .isEqualTo(expected);
+                .isEqualTo(expectedAatrox);
         assertThat(actual.get(1))
-                .isEqualTo(expected2);
+                .isEqualTo(expectedAhri);
+    }
+
+    @Test
+    public void whenPersist_thenReturnChampion(){
+        //when
+        championMapper.persist(expectedAhri);
+        //then
+        assertThat(championMapper.findByName(expectedAhri.getName()))
+                .isEqualTo(new Champion(1L, AHRI));
+
     }
 
     @Test(expected = DuplicateKeyException.class)
-    public void whenCreateChampionWithSameId_thenExceptionOccurs(){
-        //given
-        championMapper.create(expected);
-        expected2 = new Champion(1L, "Ahri");
+    public void whenPersistWithTheSameName_thenExceptionOccur(){
         //when
-        championMapper.create(expected2);
+        championMapper.persist(expectedAhri);
+        championMapper.persist(expectedAhri);
         //then
-        //DuplicateKeyException occurs
+
     }
 
     @Test
     public void whenUpdate_thenUpdateChampionEntity(){
         //given
-        championMapper.create(expected);
-        expected2 = new Champion(3L, "Ahri");
+        championMapper.persist(expectedAatrox);
         //when
-        championMapper.update(1L, expected2);
-        System.out.println(championMapper.findOne(1L));
-        Champion prev = championMapper.findOne(1L);
-        Champion actual = championMapper.findOne(3L);
+        championMapper.update(1L, expectedAhri);
+        Champion prev = championMapper.findById(1L);
+        Champion actual = championMapper.findById(2L);
         //then
-        assertThat(prev)
-                .isEqualTo(null);
+        assertThat(prev).isNull();
         assertThat(actual)
-                .isEqualTo(expected2);
+                .isEqualTo(expectedAhri);
 
+    }
+
+    @Test(expected = DuplicateKeyException.class)
+    public void whenUpdateToUsedId_thenExceptionOccurs(){
+        //given
+        championMapper.persist(expectedAatrox);
+        championMapper.persist(expectedAhri);
+        //when
+        championMapper.update(1L, new Champion(2L, "Mark"));
+        //then
+        //DuplicateKeyException occurs
+    }
+
+    @Test(expected = DuplicateKeyException.class)
+    public void whenUpdateToUsedName_thenExceptionOccurs(){
+        //given
+        championMapper.persist(expectedAatrox);
+        championMapper.persist(expectedAhri);
+        //when
+        championMapper.update(1L, new Champion(1L, "Ahri"));
+        //then
+        //DuplicateKeyException occurs
     }
 
     @Test
     public void whenDeleteById_theDeleteChampion(){
         //given
-        championMapper.create(expected);
-        Champion previous = championMapper.findOne(1L);
+        championMapper.persist(expectedAatrox);
+        Champion previous = championMapper.findById(1L);
         assertThat(previous)
-                .isEqualTo(expected);
+                .isEqualTo(expectedAatrox);
         //when
         championMapper.deleteById(1L);
-        Champion actual = championMapper.findOne(1L);
+        Champion actual = championMapper.findById(1L);
         //then
-        assertThat(actual)
-                .isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
 }

--- a/src/test/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapperTest.java
+++ b/src/test/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapperTest.java
@@ -24,7 +24,9 @@ public class ChampionMapperTest {
     private static final String AATROX = "Aatrox";
     private static final String AHRI = "Ahri";
     private static final Long id1 = 1L;
+    public static final Long ID_1 = id1;
     private static final Long id2 = 2L;
+    public static final Long ID_2 = id2;
     @Autowired
     private ChampionMapper championMapper;
     private Champion expectedAatrox;
@@ -33,8 +35,8 @@ public class ChampionMapperTest {
 
     @Before
     public void setUp() throws Exception {
-        expectedAatrox = new Champion(id1, AATROX);
-        expectedAhri = new Champion(id2, AHRI);
+        expectedAatrox = new Champion(ID_1, AATROX);
+        expectedAhri = new Champion(ID_2, AHRI);
     }
 
     @Test
@@ -42,7 +44,7 @@ public class ChampionMapperTest {
         //given
         championMapper.persist(expectedAatrox);
         //when
-        Champion actual = championMapper.findById(id1);
+        Champion actual = championMapper.findById(ID_1);
         //then
         assertThat(actual)
                 .isEqualTo(expectedAatrox);
@@ -70,7 +72,7 @@ public class ChampionMapperTest {
         championMapper.persist(expectedAhri);
         //then
         assertThat(championMapper.findByName(expectedAhri.getName()))
-                .isEqualTo(new Champion(id1, AHRI));
+                .isEqualTo(new Champion(ID_1, AHRI));
 
     }
 
@@ -88,9 +90,9 @@ public class ChampionMapperTest {
         //given
         championMapper.persist(expectedAatrox);
         //when
-        championMapper.update(id1, expectedAhri);
-        Champion prev = championMapper.findById(id1);
-        Champion actual = championMapper.findById(id2);
+        championMapper.update(ID_1, expectedAhri);
+        Champion prev = championMapper.findById(ID_1);
+        Champion actual = championMapper.findById(ID_2);
         //then
         assertThat(prev).isNull();
         assertThat(actual)
@@ -99,23 +101,12 @@ public class ChampionMapperTest {
     }
 
     @Test(expected = DuplicateKeyException.class)
-    public void whenUpdateToUsedId_thenExceptionOccurs(){
-        //given
-        championMapper.persist(expectedAatrox);
-        championMapper.persist(expectedAhri);
-        //when
-        championMapper.update(id1, new Champion(id2, "Mark"));
-        //then
-        //DuplicateKeyException throws
-    }
-
-    @Test(expected = DuplicateKeyException.class)
     public void whenUpdateToUsedName_thenExceptionOccurs(){
         //given
         championMapper.persist(expectedAatrox);
         championMapper.persist(expectedAhri);
         //when
-        championMapper.update(id1, new Champion(id1, "Ahri"));
+        championMapper.update(ID_1, new Champion(ID_1, "Ahri"));
         //then
         //DuplicateKeyException throws
     }
@@ -124,12 +115,12 @@ public class ChampionMapperTest {
     public void whenDeleteById_theDeleteChampion(){
         //given
         championMapper.persist(expectedAatrox);
-        Champion previous = championMapper.findById(id1);
+        Champion previous = championMapper.findById(ID_1);
         assertThat(previous)
                 .isEqualTo(expectedAatrox);
         //when
-        championMapper.deleteById(id1);
-        Champion actual = championMapper.findById(id1);
+        championMapper.deleteById(ID_1);
+        Champion actual = championMapper.findById(ID_1);
         //then
         assertThat(actual).isNull();
     }

--- a/src/test/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapperTest.java
+++ b/src/test/java/pl/jakubkozlowski/learning/firststeps/mapper/ChampionMapperTest.java
@@ -23,7 +23,8 @@ public class ChampionMapperTest {
 
     private static final String AATROX = "Aatrox";
     private static final String AHRI = "Ahri";
-
+    private static final Long id1 = 1L;
+    private static final Long id2 = 2L;
     @Autowired
     private ChampionMapper championMapper;
     private Champion expectedAatrox;
@@ -32,8 +33,8 @@ public class ChampionMapperTest {
 
     @Before
     public void setUp() throws Exception {
-        expectedAatrox = new Champion(1L, AATROX);
-        expectedAhri = new Champion(2L, AHRI);
+        expectedAatrox = new Champion(id1, AATROX);
+        expectedAhri = new Champion(id2, AHRI);
     }
 
     @Test
@@ -41,7 +42,7 @@ public class ChampionMapperTest {
         //given
         championMapper.persist(expectedAatrox);
         //when
-        Champion actual = championMapper.findById(1L);
+        Champion actual = championMapper.findById(id1);
         //then
         assertThat(actual)
                 .isEqualTo(expectedAatrox);
@@ -55,6 +56,8 @@ public class ChampionMapperTest {
         //when
         List<Champion> actual = championMapper.findAll();
         //then
+        assertThat(actual.size())
+                .isEqualTo(2);
         assertThat(actual.get(0))
                 .isEqualTo(expectedAatrox);
         assertThat(actual.get(1))
@@ -62,12 +65,12 @@ public class ChampionMapperTest {
     }
 
     @Test
-    public void whenPersist_thenReturnChampion(){
+    public void whenPersist_thenIdAutoincrementsAndReturnsChampion(){
         //when
         championMapper.persist(expectedAhri);
         //then
         assertThat(championMapper.findByName(expectedAhri.getName()))
-                .isEqualTo(new Champion(1L, AHRI));
+                .isEqualTo(new Champion(id1, AHRI));
 
     }
 
@@ -85,9 +88,9 @@ public class ChampionMapperTest {
         //given
         championMapper.persist(expectedAatrox);
         //when
-        championMapper.update(1L, expectedAhri);
-        Champion prev = championMapper.findById(1L);
-        Champion actual = championMapper.findById(2L);
+        championMapper.update(id1, expectedAhri);
+        Champion prev = championMapper.findById(id1);
+        Champion actual = championMapper.findById(id2);
         //then
         assertThat(prev).isNull();
         assertThat(actual)
@@ -101,9 +104,9 @@ public class ChampionMapperTest {
         championMapper.persist(expectedAatrox);
         championMapper.persist(expectedAhri);
         //when
-        championMapper.update(1L, new Champion(2L, "Mark"));
+        championMapper.update(id1, new Champion(id2, "Mark"));
         //then
-        //DuplicateKeyException occurs
+        //DuplicateKeyException throws
     }
 
     @Test(expected = DuplicateKeyException.class)
@@ -112,21 +115,21 @@ public class ChampionMapperTest {
         championMapper.persist(expectedAatrox);
         championMapper.persist(expectedAhri);
         //when
-        championMapper.update(1L, new Champion(1L, "Ahri"));
+        championMapper.update(id1, new Champion(id1, "Ahri"));
         //then
-        //DuplicateKeyException occurs
+        //DuplicateKeyException throws
     }
 
     @Test
     public void whenDeleteById_theDeleteChampion(){
         //given
         championMapper.persist(expectedAatrox);
-        Champion previous = championMapper.findById(1L);
+        Champion previous = championMapper.findById(id1);
         assertThat(previous)
                 .isEqualTo(expectedAatrox);
         //when
-        championMapper.deleteById(1L);
-        Champion actual = championMapper.findById(1L);
+        championMapper.deleteById(id1);
+        Champion actual = championMapper.findById(id1);
         //then
         assertThat(actual).isNull();
     }

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,5 +1,6 @@
 drop table if exists champion;
 CREATE TABLE IF NOT EXISTS `champion` (
     `id` integer primary key auto_increment,
-    `name` varchar(255) NOT NULL
+    `name` varchar(255) NOT NULL,
+    UNIQUE KEY `name` (`name`)
 )


### PR DESCRIPTION
Change persist method to return actual entity.
Change Unit Tests according to persist method changes.
Add DirtiesContext annotation to reset Autoincrement of h2 table during tests
Add Champion constructor to enable to create its insatnce  without giving id parameter.
Make `name` column of h2 table UNIQUE.